### PR TITLE
downgraded Django due to error

### DIFF
--- a/drivingBackend/settings.py
+++ b/drivingBackend/settings.py
@@ -20,6 +20,7 @@ import dj_database_url
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@ certifi==2020.4.5.2
 chardet==3.0.4
 colorama==0.4.3
 dj-database-url==0.5.0
-Django==4.1
+Django==4.0
 django-cors-headers==3.3.0
 django-filter==2.3.0
 django-heroku==0.3.1
-djangorestframework==3.11.0
+djangorestframework==3.11.0 
 gunicorn==20.0.4
 idna==2.9
 importlib-metadata==1.6.1


### PR DESCRIPTION
**Heroku build resulted in the following error:**

```bash
whitenoise.storage.MissingFileError: The file 'rest_framework/css/bootstrap-theme.min.css.map' could not be found with <whitenoise.storage.CompressedManifestStaticFilesStorage object at 0x7fa79f888af0>.
       The CSS file 'rest_framework/css/bootstrap-theme.min.css' references a file which could not be found:
         rest_framework/css/bootstrap-theme.min.css.map
       Please check the URL references in this CSS file, particularly any
       relative paths which might be pointing to the wrong location.
 !     Error while running '$ python manage.py collectstatic --noinput'.
       See traceback above for details.
```

**Solution:** StackOverflow recommendation to downgrade to Django v4.0 as the issue appears to be with v4.1-
https://stackoverflow.com/questions/73406581/python-manage-py-collectstatic-error-cannot-find-rest-framework-bootstrap-min-c